### PR TITLE
[moa-64] Exception type 문제 수정

### DIFF
--- a/src/main/java/com/moa/moa/global/common/message/FailHttpMessage.java
+++ b/src/main/java/com/moa/moa/global/common/message/FailHttpMessage.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum FailHttpMessage {
+public enum FailHttpMessage implements HttpMessage {
     // 400
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청 입니다."),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력값 입니다."),
@@ -47,7 +47,7 @@ public enum FailHttpMessage {
      */
     @Getter
     @RequiredArgsConstructor
-    public enum Auth {
+    public enum Auth implements HttpMessage {
         // 400
         BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청 입니다."),
         INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력값 입니다."),
@@ -89,7 +89,7 @@ public enum FailHttpMessage {
      */
     @Getter
     @RequiredArgsConstructor
-    public enum Custom {
+    public enum Custom implements HttpMessage {
         // 400
         BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청 입니다."),
         INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력값 입니다."),
@@ -131,7 +131,7 @@ public enum FailHttpMessage {
      */
     @Getter
     @RequiredArgsConstructor
-    public enum Member {
+    public enum Member implements HttpMessage {
         // 400
         BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청 입니다."),
         INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력값 입니다."),
@@ -173,7 +173,7 @@ public enum FailHttpMessage {
      */
     @Getter
     @RequiredArgsConstructor
-    public enum Item {
+    public enum Item implements HttpMessage {
         // 400
         BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청 입니다."),
         INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력값 입니다."),
@@ -215,7 +215,7 @@ public enum FailHttpMessage {
      */
     @Getter
     @RequiredArgsConstructor
-    public enum Place {
+    public enum Place implements HttpMessage {
         // 400
         BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청 입니다."),
         INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력값 입니다."),
@@ -257,7 +257,7 @@ public enum FailHttpMessage {
      */
     @Getter
     @RequiredArgsConstructor
-    public enum Question {
+    public enum Question implements HttpMessage {
         // 200
         // 400
         BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청 입니다."),
@@ -300,7 +300,7 @@ public enum FailHttpMessage {
      */
     @Getter
     @RequiredArgsConstructor
-    public enum Review {
+    public enum Review implements HttpMessage {
         // 400
         BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청 입니다."),
         INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력값 입니다."),
@@ -342,7 +342,7 @@ public enum FailHttpMessage {
      */
     @Getter
     @RequiredArgsConstructor
-    public enum Shop {
+    public enum Shop implements HttpMessage {
         // 400
         BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청 입니다."),
         INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력값 입니다."),
@@ -384,7 +384,7 @@ public enum FailHttpMessage {
      */
     @Getter
     @RequiredArgsConstructor
-    public enum Wish {
+    public enum Wish implements HttpMessage {
         // 400
         BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청 입니다."),
         INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력값 입니다."),
@@ -426,7 +426,7 @@ public enum FailHttpMessage {
      */
     @Getter
     @RequiredArgsConstructor
-    public enum Image {
+    public enum Image implements HttpMessage {
         // 400
         BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청 입니다."),
         INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력값 입니다."),

--- a/src/main/java/com/moa/moa/global/common/message/HttpMessage.java
+++ b/src/main/java/com/moa/moa/global/common/message/HttpMessage.java
@@ -1,0 +1,8 @@
+package com.moa.moa.global.common.message;
+
+import org.springframework.http.HttpStatus;
+
+public interface HttpMessage {
+    HttpStatus getStatus();
+    String getMessage();
+}

--- a/src/main/java/com/moa/moa/global/common/message/SuccessHttpMessage.java
+++ b/src/main/java/com/moa/moa/global/common/message/SuccessHttpMessage.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum SuccessHttpMessage {
+public enum SuccessHttpMessage implements HttpMessage {
     // 200
     OK(HttpStatus.OK, "성공"),
     CREATED(HttpStatus.CREATED, "리소스가 생성되었습니다."),
@@ -27,7 +27,7 @@ public enum SuccessHttpMessage {
      */
     @Getter
     @RequiredArgsConstructor
-    public enum Auth {
+    public enum Auth implements HttpMessage {
         // 200
         OK(HttpStatus.OK, "성공"),
         CREATED(HttpStatus.CREATED, "리소스가 생성되었습니다."),
@@ -49,7 +49,7 @@ public enum SuccessHttpMessage {
      */
     @Getter
     @RequiredArgsConstructor
-    public enum Custom {
+    public enum Custom implements HttpMessage {
         // 200
         OK(HttpStatus.OK, "성공"),
         CREATED(HttpStatus.CREATED, "리소스가 생성되었습니다."),
@@ -71,7 +71,7 @@ public enum SuccessHttpMessage {
      */
     @Getter
     @RequiredArgsConstructor
-    public enum Member {
+    public enum Member implements HttpMessage {
         // 200
         OK(HttpStatus.OK, "성공"),
         CREATED(HttpStatus.CREATED, "리소스가 생성되었습니다."),
@@ -93,7 +93,7 @@ public enum SuccessHttpMessage {
      */
     @Getter
     @RequiredArgsConstructor
-    public enum Item {
+    public enum Item implements HttpMessage {
         // 200
         OK(HttpStatus.OK, "성공"),
         CREATED(HttpStatus.CREATED, "리소스가 생성되었습니다."),
@@ -115,7 +115,7 @@ public enum SuccessHttpMessage {
      */
     @Getter
     @RequiredArgsConstructor
-    public enum Place {
+    public enum Place implements HttpMessage {
         // 200
         OK(HttpStatus.OK, "성공"),
         CREATED(HttpStatus.CREATED, "리소스가 생성되었습니다."),
@@ -137,7 +137,7 @@ public enum SuccessHttpMessage {
      */
     @Getter
     @RequiredArgsConstructor
-    public enum Question {
+    public enum Question implements HttpMessage {
         // 200
         OK(HttpStatus.OK, "성공"),
         CREATED(HttpStatus.CREATED, "리소스가 생성되었습니다."),
@@ -159,7 +159,7 @@ public enum SuccessHttpMessage {
      */
     @Getter
     @RequiredArgsConstructor
-    public enum Review {
+    public enum Review implements HttpMessage {
         // 200
         OK(HttpStatus.OK, "성공"),
         CREATED(HttpStatus.CREATED, "리소스가 생성되었습니다."),
@@ -181,7 +181,7 @@ public enum SuccessHttpMessage {
      */
     @Getter
     @RequiredArgsConstructor
-    public enum Shop {
+    public enum Shop implements HttpMessage {
         // 200
         OK(HttpStatus.OK, "성공"),
         CREATED(HttpStatus.CREATED, "리소스가 생성되었습니다."),
@@ -203,7 +203,7 @@ public enum SuccessHttpMessage {
      */
     @Getter
     @RequiredArgsConstructor
-    public enum Wish {
+    public enum Wish implements HttpMessage {
         // 200
         OK(HttpStatus.OK, "성공"),
         CREATED(HttpStatus.CREATED, "리소스가 생성되었습니다."),
@@ -225,7 +225,7 @@ public enum SuccessHttpMessage {
      */
     @Getter
     @RequiredArgsConstructor
-    public enum Image {
+    public enum Image implements HttpMessage {
         // 200
         OK(HttpStatus.OK, "성공"),
         CREATED(HttpStatus.CREATED, "리소스가 생성되었습니다."),

--- a/src/main/java/com/moa/moa/global/exception/BusinessException.java
+++ b/src/main/java/com/moa/moa/global/exception/BusinessException.java
@@ -1,6 +1,7 @@
 package com.moa.moa.global.exception;
 
 import com.moa.moa.global.common.message.FailHttpMessage;
+import com.moa.moa.global.common.message.HttpMessage;
 import lombok.*;
 import org.springframework.http.HttpStatus;
 
@@ -14,7 +15,7 @@ public class BusinessException extends RuntimeException {
     private HttpStatus status;
     private String message;
 
-    public BusinessException(FailHttpMessage response) {
+    public BusinessException(HttpMessage response) {
         super(response.getMessage());
         this.status = response.getStatus();
         this.message = response.getMessage();

--- a/src/main/java/com/moa/moa/global/exception/InternalException.java
+++ b/src/main/java/com/moa/moa/global/exception/InternalException.java
@@ -1,6 +1,7 @@
 package com.moa.moa.global.exception;
 
 import com.moa.moa.global.common.message.FailHttpMessage;
+import com.moa.moa.global.common.message.HttpMessage;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,7 +9,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 /**
- * 500번대 에러를 처리하기 위한 예외 클래스. <br><br>
+ * @see 500번대 에러를 처리하기 위한 예외 클래스. <br><br>
  * Ex) 외부 API 통신 오류 및 Converter 오류
  */
 @Getter
@@ -18,7 +19,7 @@ public class InternalException extends RuntimeException {
     private HttpStatus status;
     private String message;
 
-    public InternalException(FailHttpMessage response) {
+    public InternalException(HttpMessage response) {
         super(response.getMessage());
         this.status = response.getStatus();
         this.message = response.getMessage();


### PR DESCRIPTION
Exception Message를 inner enum으로 사용하여 발생하는 type error를 해결하기 위해
HttpException interface 생성하여 모든 HttpMessage에서 구현체로 사용