### PR TITLE
[moa-81] Wish - 렌탈샵 찜 추가 기능 구현

### DIFF
--- a/src/main/java/com/moa/moa/api/member/wish/application/WishService.java
+++ b/src/main/java/com/moa/moa/api/member/wish/application/WishService.java
@@ -3,12 +3,17 @@ package com.moa.moa.api.member.wish.application;
 import com.moa.moa.api.member.member.domain.entity.Member;
 import com.moa.moa.api.member.wish.application.mapstruct.WishMapstructMapper;
 import com.moa.moa.api.member.wish.domain.WishProcessor;
+import com.moa.moa.api.member.wish.domain.dto.AddWishDto;
 import com.moa.moa.api.member.wish.domain.dto.FindAllWishDto;
 import com.moa.moa.api.member.wish.domain.entity.Wish;
 import com.moa.moa.api.place.place.domain.entity.Place;
 import com.moa.moa.api.shop.placeshop.domain.entity.PlaceShop;
 import com.moa.moa.api.shop.review.domain.entity.Review;
+import com.moa.moa.api.shop.shop.domain.ShopProcessor;
+import com.moa.moa.api.shop.shop.domain.entity.Shop;
+import com.moa.moa.global.common.message.FailHttpMessage;
 import com.moa.moa.global.common.response.PageExternalDto;
+import com.moa.moa.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -16,12 +21,14 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class WishService {
     private final WishProcessor wishProcessor;
+    private final ShopProcessor shopProcessor;
     private final WishMapstructMapper wishMapstructMapper;
 
     public PageExternalDto.Response<List<FindAllWishDto.Response>> findAllWish(Member member, Pageable pageable) {
@@ -52,5 +59,19 @@ public class WishService {
         }
 
         return wishMapstructMapper.of(findAllWishList, pageable, wishProcessor.countMyWish(member));
+    }
+
+    public AddWishDto.Response addWish(AddWishDto.Request request, Member member) {
+        Shop shop = shopProcessor.findShopById(request.shopId())
+                .orElseThrow(() -> new BusinessException(FailHttpMessage.Shop.NOT_FOUND));
+
+        Optional<Wish> optionalWish = wishProcessor.findWishByShopAndMember(shop, member);
+        if (optionalWish.isPresent()) {
+            throw new BusinessException(FailHttpMessage.Wish.CONFLICT);
+        }
+
+        Wish wish = wishProcessor.addWish(wishMapstructMapper.addOf(shop.getId(), member.getId()));
+
+        return wishMapstructMapper.addOf(wish);
     }
 }

--- a/src/main/java/com/moa/moa/api/member/wish/application/mapstruct/WishMapstructMapper.java
+++ b/src/main/java/com/moa/moa/api/member/wish/application/mapstruct/WishMapstructMapper.java
@@ -1,6 +1,7 @@
 package com.moa.moa.api.member.wish.application.mapstruct;
 
 import com.moa.moa.api.address.address.domain.entity.Address;
+import com.moa.moa.api.member.wish.domain.dto.AddWishDto;
 import com.moa.moa.api.member.wish.domain.dto.FindAllWishDto;
 import com.moa.moa.api.member.wish.domain.entity.Wish;
 import com.moa.moa.api.place.place.domain.entity.Place;
@@ -78,4 +79,14 @@ public interface WishMapstructMapper {
     PageExternalDto.Response<List<FindAllWishDto.Response>> of(List<FindAllWishDto.Response> responses,
                                                                Pageable pageable,
                                                                Integer totalSize);
+
+    AddWishDto.Response addOf(Wish wish);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "deletedAt", ignore = true)
+    @Mapping(target = "member.id", source = "memberId")
+    @Mapping(target = "shop.id", source = "shopId")
+    Wish addOf(Long shopId, Long memberId);
 }

--- a/src/main/java/com/moa/moa/api/member/wish/domain/WishProcessor.java
+++ b/src/main/java/com/moa/moa/api/member/wish/domain/WishProcessor.java
@@ -27,4 +27,8 @@ public class WishProcessor {
     public Integer countMyWish(Member member) {
         return wishRepository.countByMember(member);
     }
+
+    public Wish addWish(Wish wish) {
+        return wishRepository.save(wish);
+    }
 }

--- a/src/main/java/com/moa/moa/api/member/wish/domain/dto/AddWishDto.java
+++ b/src/main/java/com/moa/moa/api/member/wish/domain/dto/AddWishDto.java
@@ -1,8 +1,10 @@
 package com.moa.moa.api.member.wish.domain.dto;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 
 public record AddWishDto() {
+    @Builder
     public record Request(
             @NotNull
             Long shopId

--- a/src/main/java/com/moa/moa/api/member/wish/domain/persistence/WishDslRepositoryImpl.java
+++ b/src/main/java/com/moa/moa/api/member/wish/domain/persistence/WishDslRepositoryImpl.java
@@ -34,7 +34,7 @@ import static com.moa.moa.api.time.operatingtime.domain.entity.QOperatingTime.op
 import static com.moa.moa.api.time.specificday.domain.entity.QSpecificDay.specificDay;
 
 @RequiredArgsConstructor
-public class WishDslRepositoryImpl implements WishDslRepository{
+public class WishDslRepositoryImpl implements WishDslRepository {
     private final JPAQueryFactory queryFactory;
     private final CursorPaginationUtil<Wish> cursorPaginationUtil;
 
@@ -59,6 +59,7 @@ public class WishDslRepositoryImpl implements WishDslRepository{
                 .leftJoin(wish.shop.address, address1).fetchJoin()
                 .leftJoin(wish.shop.businessTime, businessTime).fetchJoin()
                 .where(wish.member.eq(userMember)
+                        .and(cursorPaginationUtil.ltCursorId(wish.id, pageable.getPageNumber()))
                         .and(wish.deletedAt.isNull())
                         .and(shop.deletedAt.isNull())
                         .and(shop.member.deletedAt.isNull())
@@ -67,6 +68,7 @@ public class WishDslRepositoryImpl implements WishDslRepository{
                         .and(shop.businessTime.deletedAt.isNull())
                 )
                 .orderBy(wish.id.asc())
+                .limit(pageable.getPageSize() + 1)
                 .fetch();
 
         for (Wish wish : wishes) {

--- a/src/main/java/com/moa/moa/api/member/wish/presentation/WishController.java
+++ b/src/main/java/com/moa/moa/api/member/wish/presentation/WishController.java
@@ -16,7 +16,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import java.net.URI;
 import java.nio.file.attribute.UserPrincipal;
 import java.util.List;
 
@@ -35,7 +37,18 @@ public class WishController {
     @PostMapping
     public ResponseEntity<AddWishDto.Response> addWish(@Valid @RequestBody final AddWishDto.Request request,
                                                        @AuthenticationPrincipal UserPrincipal user) {
-        return ResponseEntity.created(null).body(null);
+        // TODO : 회원 관련 기능이 완성되면 삭제할 것
+        Member member = memberRepository.findByEmail("three@moa.com").get();
+
+        AddWishDto.Response response = wishService.addWish(request, member);
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(response.id())
+                .toUri();
+
+        return ResponseEntity.created(location).body(response);
     }
 
     @Operation(summary = "나의 찜 목록 조회", responses = {@ApiResponse(responseCode = GET)})

--- a/src/test/java/com/moa/moa/api/member/wish/presentation/WishControllerTest.java
+++ b/src/test/java/com/moa/moa/api/member/wish/presentation/WishControllerTest.java
@@ -221,11 +221,11 @@ class WishControllerTest {
     @Test
     @DisplayName("렌탈샵 찜 추가 성공")
     void t2() throws Exception {
-        Shop shop = shopRepository.findShopById(1L).get();
+        Shop shop = shopRepository.findAll().get(0);
         Member member = memberRepository.findByEmail("three@moa.com").get();
 
         AddWishDto.Request request = AddWishDto.Request.builder()
-                .shopId(1L)
+                .shopId(shop.getId())
                 .build();
 
         ResultActions actions = mvc


### PR DESCRIPTION
### 구현 목록
- 렌탈샵 찜 추가 api 구현
- 해당 기능의 test 코드 구현
  - Controller (SpringBootTest)
  - Service (mockito)
  - Repository (SpringBootTest)

### 추후 적용 필요
- 회원 기능이 관련 코드는 TODO로 주석 남겨 놓았습니다.